### PR TITLE
feat: fix devtools warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuex-context",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Write fully type inferred Vuex modules",
   "main": "dist/index.common.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -39,15 +39,14 @@
     "ts-jest": "^23.0.0",
     "tslint-config-prettier": "^1.15.0",
     "typescript": "^3.0.0",
-    "vue": "^2.5.17",
+    "vue": "^2.6.10",
     "vue-class-component": "^6.3.2",
     "vue-property-decorator": "^7.0.0",
     "vue-router": "^3.0.1",
-    "vue-template-compiler": "^2.5.17",
-    "vuex": "^3.0.1"
+    "vue-template-compiler": "^2.6.10",
+    "vuex": "^3.1.0"
   },
   "peerDependencies": {
-    "vue": "^2.5.17",
-    "vuex": "^3.0.1"
+    "vuex": "^3.1.0"
   }
 }

--- a/samples/store/index.ts
+++ b/samples/store/index.ts
@@ -7,6 +7,7 @@ import * as todo from "./todo";
 Vue.use(Vuex);
 
 const options: StoreOptions<any> = {
+  strict: true,
   modules: {
     todo,
     counter

--- a/samples/views/Home.vue
+++ b/samples/views/Home.vue
@@ -7,7 +7,7 @@
     <div v-for="todo in todos" :key="todo.id">
       <label>
         {{ todo.text }}
-        <input type="checkbox" :value="todo.done" @change="toggleTodo(todo)">
+        <input type="checkbox" :checked="todo.done" @change="toggleTodo(todo)">
       </label>
     </div>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8715,10 +8715,10 @@ vue-style-loader@^4.1.0:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.5.17:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.9.tgz#26600415ff81a7a241aebc2d4e0abaa0f1a07915"
-  integrity sha512-QgO0LSCdeH6zUMSgtqel+yDWsZWQPXiWBdFg9qzOhWfQL8vZ+ywinAzE04rm1XrWc+3SU0YAdWISlEgs/i8WWA==
+vue-template-compiler@^2.6.10:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz#323b4f3495f04faa3503337a82f5d6507799c9cc"
+  integrity sha512-jVZkw4/I/HT5ZMvRnhv78okGusqe0+qH2A0Em0Cp8aq78+NK9TII263CDVz2QXZsIT+yyV/gZc/j/vlwa+Epyg==
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
@@ -8728,12 +8728,12 @@ vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue@^2.5.17:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.9.tgz#415c1cc1a5ed00c8f0acdd0a948139d12b7ea6b3"
-  integrity sha512-t1+tvH8hybPM86oNne3ZozCD02zj/VoZIiojOBPJLjwBn7hxYU5e1gBObFpq8ts1NEn1VhPf/hVXBDAJ3X5ljg==
+vue@^2.6.10:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.10.tgz#a72b1a42a4d82a721ea438d1b6bf55e66195c637"
+  integrity sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==
 
-vuex@^3.0.1:
+vuex@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.1.0.tgz#634b81515cf0cfe976bd1ffe9601755e51f843b9"
   integrity sha512-mdHeHT/7u4BncpUZMlxNaIdcN/HIt1GsGG5LKByArvYG/v6DvHcOxvDCts+7SRdCoIRGllK8IMZvQtQXLppDYg==


### PR DESCRIPTION
- directly use the module's contexts:
  - remove need to prefix commit / dispatch
  - remove now unnecessary proxies for state / getters
- fix bug with vue devtools by making each property of the context instance non configurable / enumerable